### PR TITLE
修复 SpotSymbolFilter 的 missing field `max_position`"

### DIFF
--- a/src/response/http.rs
+++ b/src/response/http.rs
@@ -186,6 +186,7 @@ pub enum SpotSymbolFilter {
     #[serde(rename = "MAX_POSITION")]
     MaxPosition {
         #[serde(deserialize_with = "string_as_f64")]
+        #[serde(rename = "maxPosition")]
         max_position: f64,
     },
     #[serde(rename = "EXCHANGE_MAX_NUM_ORDERS")]


### PR DESCRIPTION
缺少rename导致max_position无法被解析